### PR TITLE
Put snippet text `after` only in normal mode

### DIFF
--- a/lua/telescope/_extensions/ultisnips.lua
+++ b/lua/telescope/_extensions/ultisnips.lua
@@ -106,7 +106,8 @@ local ultisnips = function(opts)
       actions.select_default:replace(function(prompt_bufnr)
         local selection = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
-        vim.api.nvim_put({ selection.value.name }, "", true, true)
+        local after = vim.api.nvim_get_mode().mode == "n"
+        vim.api.nvim_put({ selection.value.name }, "", after, true)
         vim.cmd([[call UltiSnips#ExpandSnippet()]])
       end)
       return true


### PR DESCRIPTION
When calling telescope snippet function from insert mode, it is much more natural to insert the snippet text `before`.

One can now chain invocations of the snippet picker, via an insert mode mapping, with the text inserted in proper places.